### PR TITLE
受け攻めボタンの改修

### DIFF
--- a/app/views/characters/index.html.slim
+++ b/app/views/characters/index.html.slim
@@ -7,19 +7,17 @@ table.table.table-hover
   thead.thead-default 
     tr 
       th= Character.human_attribute_name(:name)
-      th 受けボタン
       th 受け数
-      th 攻めボタン
       th 攻め数
       th
     tbody 
       - @characters.each do |character|
         tr 
           td= character.name
-          td= link_to '受け', character_ukes_url(character), method: :post
-          td= character.ukes.count
-          td= link_to '攻め', character_semes_url(character), method: :post
-          td= character.semes.count
+          td= link_to character_ukes_url(character), method: :post do
+            = character.ukes.count
+          td= link_to character_semes_url(character), method: :post do
+            = character.semes.count
           td 
             = link_to '編集', edit_character_path(character), class: 'btn btn-primary mr-3'
             = link_to '削除', character, method: :delete, data: { confirm: "キャラクター「#{character.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,14 +7,16 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
-  models:
-    characters: キャラクター
-  attributes:
-    character:
-      id: ID
-      name: 名前
-      created_at: 作成日時
-      updated_at: 更新日時
+    models:
+      character: キャラクター
+      seme: 攻め
+      uke: 受け
+    attributes:
+      character:
+        id: ID
+        name: 名前
+        created_at: 作成日時
+        updated_at: 更新日時
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
Fixes #12 
受け攻めボタンを削除し、投票数を押すと＋１されるように改修しました。

[![Image from Gyazo](https://t.gyazo.com/teams/startup-technology/f2d48afd67093ecde2bba48e753f45fa.png)](https://startup-technology.gyazo.com/f2d48afd67093ecde2bba48e753f45fa)