### PR TITLE
Twitterシェアボタンを追加

### DIFF
--- a/app/views/characters/index.html.slim
+++ b/app/views/characters/index.html.slim
@@ -25,4 +25,6 @@ br
               = link_to edit_character_path(character) do
                 i.fas.fa-edit.mr-3.text-success
               = link_to character, method: :delete, data: { confirm: "キャラクター「#{character.name}」を削除します。よろしいですか？" } do 
-                i.fas.fa-trash.text-danger
+                i.fas.fa-trash.text-danger.mr-3
+              =link_to "http://twitter.com/share?url=#{request.url}/&text=#{character.name}は受け？攻め？投票してみよう！&hashtags=BLvote", title: 'Twitter', target: '_blank' do 
+                i.fab.fa-twitter


### PR DESCRIPTION
Fixes #23 

Twitterシェアボタンを追加しました。
つぶやく際はキャラクターの名前を表示できるようにしました。

[![Image from Gyazo](https://t.gyazo.com/teams/startup-technology/23a3591619ac847eacbbaef53eed7090.gif)](https://startup-technology.gyazo.com/23a3591619ac847eacbbaef53eed7090)