### PR TITLE
Twitterシェア機能に受け・攻めの現在の票数を追加

### DIFF
--- a/app/views/characters/index.html.slim
+++ b/app/views/characters/index.html.slim
@@ -20,6 +20,6 @@
             td= link_to character_semes_url(character), method: :post do
               = character.semes.count
             td 
-              =link_to "http://twitter.com/share?url=#{request.url}/&text=#{character.name}は受け？攻め？投票してみよう！&hashtags=BLvote", title: 'Twitter', target: '_blank' do 
+              =link_to "http://twitter.com/share?url=#{request.url}/&text=#{character.name}は#{character.ukes.count}受け、#{character.semes.count}攻め！あなたも投票してみよう！&hashtags=BLvote", title: 'Twitter', target: '_blank' do 
                 i.fab.fa-twitter
   = paginate @characters

--- a/app/views/characters/index.html.slim
+++ b/app/views/characters/index.html.slim
@@ -20,6 +20,6 @@
             td= link_to character_semes_url(character), method: :post do
               = character.semes.count
             td 
-              =link_to "http://twitter.com/share?url=#{request.url}/&text=#{character.name}は#{character.ukes.count}受け、#{character.semes.count}攻め！あなたも投票してみよう！&hashtags=BLvote", title: 'Twitter', target: '_blank' do 
+              =link_to "http://twitter.com/share?url=#{request.url}/&text=#{character.name}には受けが#{character.ukes.count}票、攻めが#{character.semes.count}票入ってるよ！BLvoteで投票してみよう！&hashtags=BLvote", title: 'Twitter', target: '_blank' do 
                 i.fab.fa-twitter
   = paginate @characters


### PR DESCRIPTION
[![Image from Gyazo](https://t.gyazo.com/teams/startup-technology/86fc1dfb7c5dd8f675cb31eaab42c148.png)](https://startup-technology.gyazo.com/86fc1dfb7c5dd8f675cb31eaab42c148)

現在の票数をTwitterシェア時に共有できるように設定しました。

Fixes #35 